### PR TITLE
Compatibility for React Native > 0.47 and < 0.47

### DIFF
--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerPackage.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerPackage.java
@@ -17,7 +17,7 @@ public class ReactNativeFingerprintScannerPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new ReactNativeFingerprintScannerModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Same as all other dependencies such as : https://github.com/airbnb/lottie-react-native/pull/169/files

Removing the `@override` makes it compatible with both before and after react native version 0.47.