### PR TITLE
Differentiate availablity error codes on iOS.

### DIFF
--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -20,8 +20,22 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], @true]);
     } else {
-        // Device does not support FingerprintScanner
-        callback(@[RCTMakeError(@"FingerprintScannerNotSupported", nil, nil)]);
+        NSString *errorReason;
+
+        switch (error.code) {
+            case LAErrorTouchIDNotAvailable:
+                errorReason = @"FingerprintScannerNotAvailable";
+                break;
+
+            case LAErrorTouchIDNotEnrolled:
+                errorReason = @"FingerprintScannerNotEnrolled";
+                break;
+
+            default:
+                errorReason = @"FingerprintScannerNotSupported";
+                break;
+        }
+        callback(@[RCTMakeError(errorReason, nil, nil)]);
         return;
     }
 }


### PR DESCRIPTION
Instead of always returning an error with name `FingerprintScannerNotSupported` this returns the specific error name of why the fingerprint sensor is unavailable. Specifically `FingerprintScannerNotEnrolled` is more helpful so that users can be directed to the settings app to set up touch id on iOS.