### PR TITLE
Replace PropTypes from React with form prop-types package

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Samsung and MeiZu's Fingerprint SDK supports most devices which system versions 
 
 **iOS Implementation**
 ```javascript
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { AlertIOS } from 'react-native';
 import FingerprintScanner from 'react-native-fingerprint-scanner';
+import PropTypes from 'prop-types';
 
 class FingerprintPopup extends Component {
 

--- a/examples/src/FingerprintPopup.component.android.js
+++ b/examples/src/FingerprintPopup.component.android.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   Alert,
   Image,
@@ -8,6 +8,7 @@ import {
   ViewPropTypes
 } from 'react-native';
 import FingerprintScanner from 'react-native-fingerprint-scanner';
+import PropTypes from 'prop-types';
 
 import ShakingText from './ShakingText.component';
 import styles from './FingerprintPopup.component.styles';

--- a/examples/src/FingerprintPopup.component.ios.js
+++ b/examples/src/FingerprintPopup.component.ios.js
@@ -1,6 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { AlertIOS } from 'react-native';
 import FingerprintScanner from 'react-native-fingerprint-scanner';
+import PropTypes from 'prop-types';
 
 class FingerprintPopup extends Component {
 

--- a/examples/src/ShakingText.component.js
+++ b/examples/src/ShakingText.component.js
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { Animated, Text } from 'react-native';
+import PropTypes from 'prop-types';
 
 class ShakingText extends Component {
 

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "cleanup": "rm -rf android/build ios/build yarn.lock node_modules && cd examples && rm -rf android/build android/app/build ios/build yarn.lock node_modules",
     "cleanup:android": "cd examples/android && ./gradlew clean",
     "cleanup:install": "yarn cleanup && yarn && cd examples && yarn && cd .. && yarn symlink && yarn cleanup:android"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
See https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes
Also seems to be breaking on react@16.0.0-beta.5 and react-native@0.49.3