### PR TITLE
Android ISSUE: User deletes fingerprints on device and then re-add's them, the app still says that there are no fingerprints on device

### DIFF
--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -41,18 +41,16 @@ public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaMod
     }
 
     private FingerprintIdentify getFingerprintIdentify() {
-        if (mFingerprintIdentify == null) {
-            mReactContext.addLifecycleEventListener(this);
-            mFingerprintIdentify = new FingerprintIdentify(getCurrentActivity(),
-                    new FingerprintIdentifyExceptionListener() {
-                        @Override
-                        public void onCatchException(Throwable exception) {
-                            mReactContext.removeLifecycleEventListener(
-                                    ReactNativeFingerprintScannerModule.this);
-                        }
-                    });
-        }
-        return mFingerprintIdentify;
+        mReactContext.addLifecycleEventListener(this);
+        mFingerprintIdentify = new FingerprintIdentify(getCurrentActivity(),
+                new FingerprintIdentifyExceptionListener() {
+                    @Override
+                    public void onCatchException(Throwable exception) {
+                        mReactContext.removeLifecycleEventListener(
+                                ReactNativeFingerprintScannerModule.this);
+                    }
+                });
+    return mFingerprintIdentify;
     }
 
     private String getErrorMessage() {


### PR DESCRIPTION
The problem (Andriod): A user is currently using an application which has fingerprint enabled and stores the password in the device's keychain. 
Then the User puts the app in the background and navigates to settings to delete all fingerprints present on the device. 
Then the user navigates to the app and tries to use his fingerprint to log in to the app. 
Then the app alerts the user "No fingerprints found"
Then the user navigates to settings and adds a fingerprint to device
Then the app does not recognize the addition the fingerprint and still shows the error "No fingerprints found"

`mFingerprintIdentify` doesn't update every time the `getErrorMessage()` function is called.

Solution:
Stop checking if `mFingerprintIdentify ` is null, instead always return a new `mFingerprintIdentify` by removing `if (mFingerprintIdentify == null)`

This PR fixes the above-mentioned issue in 2 scenarios.

Remove Fingerprints from Device:
GIVEN I am a user who has back-grounded the app
WHEN I remove my configured fingerprints from my device
THEN I expect the app to recognize that there are no fingerprints configured on the device
AND to be presented with the No Fingerprint Found prompt

Add Fingerprints to Device
GIVEN I am a user who has back-grounded the app
WHEN I add a configured fingerprint to my device
THEN I expect the app to recognize that there a fingerprint has been added to the device
AND be able to use Fingerprint Login based features