### PR TITLE
[iOS] Update evaluation policy

### DIFF
--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -17,7 +17,7 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
 
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         callback(@[[NSNull null], @true]);
     } else {
         // Device does not support FingerprintScanner
@@ -39,9 +39,9 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     }
 
     // Device has FingerprintScanner
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         // Attempt Authentication
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {


### PR DESCRIPTION
With LAPolicyDeviceOwnerAuthenticationWithBiometrics, fallback mechanism wasn't working properly. Hence updated to LAPolicyDeviceOwnerAuthentication to handle passcode in case of touchID failure