### PR TITLE
Add annotation to enable lazy/turbo packaging

### DIFF
--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -5,11 +5,13 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 import com.wei.android.lib.fingerprintidentify.FingerprintIdentify;
 import com.wei.android.lib.fingerprintidentify.base.BaseFingerprint.FingerprintIdentifyExceptionListener;
 import com.wei.android.lib.fingerprintidentify.base.BaseFingerprint.FingerprintIdentifyListener;
 
+@ReactModule(name="ReactNativeFingerprintScanner")
 public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaModule
         implements LifecycleEventListener {
     public static final int MAX_AVAILABLE_TIMES = Integer.MAX_VALUE;


### PR DESCRIPTION
In order to [enable lazy loading](http://blog.nparashuram.com/2019/04/lazy-native-modules-react-native-android.html) with `LazyReactPackage` or `TurboReactPackage`, all native modules require an annotation. This is a backwards-compatible, non-breaking change that'll affect only users who are using a non-standard react package.