### PR TITLE
Use LAPolicyDeviceOwnerAuthentication when fallback is enabled

### DIFF
--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -44,16 +44,18 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
-
+    
     // Toggle fallback button
     if (!fallbackEnabled) {
         context.localizedFallbackTitle = @"";
     }
-
+    
+     __auto_type policy = fallbackEnabled ? LAPolicyDeviceOwnerAuthentication : LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    
     // Device has FingerprintScanner
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:policy error:&error]) {
         // Attempt Authentication
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:policy
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {


### PR DESCRIPTION
'Enter Password' doesn't working. It because the policy should be LAPolicyDeviceOwnerAuthentication when fallback is enabled.

<img width="355" alt="Screen Shot 2019-05-19 at 9 55 33" src="https://user-images.githubusercontent.com/7188278/57980941-7a4bf180-7a3a-11e9-82f5-d3ef4816f277.png">

