### PR TITLE
React context

### DIFF
--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -48,7 +48,7 @@ public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaMod
             return mFingerprintIdentify;
         }
         mReactContext.addLifecycleEventListener(this);
-        mFingerprintIdentify = new FingerprintIdentify(getCurrentActivity());
+        mFingerprintIdentify = new FingerprintIdentify(mReactContext);
         mFingerprintIdentify.setSupportAndroidL(true);
         mFingerprintIdentify.setExceptionListener(
             new ExceptionListener() {


### PR DESCRIPTION
Using getCurrentActivity to instantiate FingerprintIdentify often fails when you launch another activity before the MainActivity.

With this fix, using mReactContext already defined in the class, it always works.

Please note that if there was a reason for using getCurrentActivity you can ignore the pull request.