### PR TITLE
iPhone 5 Touch id issue resolved

### DIFF
--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -23,7 +23,7 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
 
         switch (error.code) {
             case LAErrorTouchIDNotAvailable:
-                code = @"FingerprintScannerNotAvailable";
+                code = [error.localizedDescription isEqualToString:@"Biometry is not available on this device."]?@"FingerprintScannerNotSupported":@"FingerprintScannerNotAvailable";
                 message = [self getBiometryType:context];
                 break;
 


### PR DESCRIPTION
Hi Team,

in iPhone 5 there is no touch id but when we call isSensorAvailable it is returning **FingerprintScannerNotAvailable** instead of **FingerprintScannerNotSupported**.

Adding the above condition resolved the issue, please review and merge with main repo

Thanks,
Mahendra Kata 