### PR TITLE
Upgrade android to use new BiometricPrompt API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
         components:
           - tools
           - platform-tools
-          - build-tools-28.0.3
-          - android-28
+          - build-tools-29.0.2
+          - android-29
       sudo: true
       before_install:
         - nvm install --lts

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ class BiometricPopup extends Component {
 
   authCurrent() {
     FingerprintScanner
-      .authenticate({ titleText: 'Log in with Biometrics' })
+      .authenticate({ description: 'Log in with Biometrics' })
       .then(() => {
         this.props.onAuthenticate();
       });
@@ -357,11 +357,11 @@ componentDidMount() {
 }
 ```
 
-### `authenticate({ titleText="Log In", onAttempt=() => (null) })`: (Android)
+### `authenticate({ description="Log In", onAttempt=() => (null) })`: (Android)
 Starts Fingerprint authentication on Android.
 
 - Returns a `Promise`
-- `titleText: String` the title text to display in the native Android popup
+- `description: String` the title text to display in the native Android popup
 - `onAttempt: Function` - a callback function when users are trying to scan their fingerprint but failed.
 
 ```javascript
@@ -383,7 +383,7 @@ requiresLegacyAuthentication() {
 
 authCurrent() {
   FingerprintScanner
-    .authenticate({ titleText: 'Log in with Biometrics' })
+    .authenticate({ description: 'Log in with Biometrics' })
     .then(() => {
       this.props.onAuthenticate();
     });

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ It provides a **Default View** that prompts the user to place a finger to the iP
 </div>
 
 ### Android Version
+4.0.0 Prefers the new native Android BiometricPrompt lib on any Android >= v23 (M)
+4.0.0 also DEPRECATES support for the legacy library that provides support for Samsung & MeiZu phones
+
+3.0.2 and below: 
 Using an expandable Android Fingerprint API library, which combines [Samsung](http://developer.samsung.com/galaxy/pass#) and [MeiZu](http://open-wiki.flyme.cn/index.php?title=%E6%8C%87%E7%BA%B9%E8%AF%86%E5%88%ABAPI)'s official Fingerprint API.
 
 Samsung and MeiZu's Fingerprint SDK supports most devices which system versions less than Android 6.0.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
     // androidx:biometric now supports fingerprint back to Android v23
     implementation "androidx.biometric:biometric:1.0.1"
 
@@ -49,5 +49,5 @@ dependencies {
     // 1.2.3 is the minimum version compatible with androidx.
     // See https://github.com/uccmawei/FingerprintIdentify/issues/74
     // (translation https://translate.google.com/translate?sl=zh-CN&tl=en&u=https://github.com/uccmawei/FingerprintIdentify/issues/74)
-    implementation "com.wei.android.lib:fingerprintidentify:${safeExtGet("fingerprintidentify", "1.2.6")}"
+    compile "com.wei.android.lib:fingerprintidentify:${safeExtGet("fingerprintidentify", "1.2.6")}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,12 +21,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 25)
-    buildToolsVersion safeExtGet('buildToolsVersion', '25.0.3')
+    compileSdkVersion safeExtGet('compileSdkVersion', 29)
+    buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 25)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
     }
@@ -42,8 +42,6 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    // 1.2.3 is the minimum version compatible with androidx.
-    // See https://github.com/uccmawei/FingerprintIdentify/issues/74
-    // (translation https://translate.google.com/translate?sl=zh-CN&tl=en&u=https://github.com/uccmawei/FingerprintIdentify/issues/74)
-    compile "com.wei.android.lib:fingerprintidentify:${safeExtGet("fingerprintidentify", "1.2.6")}"
+    // androidx:biometric now supports fingerprint back to Android v23
+    implementation "androidx.biometric:biometric:1.0.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,13 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
     // androidx:biometric now supports fingerprint back to Android v23
     implementation "androidx.biometric:biometric:1.0.1"
+
+    // retain fingerprintScanner lib for compat with Android v16-23 device-specific drivers (Samsung & MeiZu)
+    // 1.2.3 is the minimum version compatible with androidx.
+    // See https://github.com/uccmawei/FingerprintIdentify/issues/74
+    // (translation https://translate.google.com/translate?sl=zh-CN&tl=en&u=https://github.com/uccmawei/FingerprintIdentify/issues/74)
+    implementation "com.wei.android.lib:fingerprintidentify:${safeExtGet("fingerprintidentify", "1.2.6")}"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.hieuvp.fingerprint">
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
     <uses-permission android:name="com.fingerprints.service.ACCESS_FINGERPRINT_MANAGER" />
     <uses-permission
         android:name="com.samsung.android.providers.context.permission.WRITE_USE_APP_FEATURE_SURVEY" />

--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 @ReactModule(name="ReactNativeFingerprintScanner")
 public class ReactNativeFingerprintScannerModule
@@ -110,6 +109,38 @@ public class ReactNativeFingerprintScannerModule
             });
     }
 
+    private String errString(int errCode) {
+        switch (errCode) {
+            case BiometricPrompt.ERROR_CANCELED:
+                return "SystemCancel";
+            case BiometricPrompt.ERROR_HW_NOT_PRESENT:
+                return "FingerprintScannerNotSupported";
+            case BiometricPrompt.ERROR_HW_UNAVAILABLE:
+                return "FingerprintScannerNotAvailable";
+            case BiometricPrompt.ERROR_LOCKOUT:
+                return "DeviceLocked";
+            case BiometricPrompt.ERROR_LOCKOUT_PERMANENT:
+                return "DeviceLocked";
+            case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
+                return "UserCancel";
+            case BiometricPrompt.ERROR_NO_BIOMETRICS:
+                return "FingerprintScannerNotEnrolled";
+            case BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL:
+                return "PasscodeNotSet";
+            case BiometricPrompt.ERROR_NO_SPACE:
+                return "DeviceOutOfMemory";
+            case BiometricPrompt.ERROR_TIMEOUT:
+                return "AuthenticationTimeout";
+            case BiometricPrompt.ERROR_UNABLE_TO_PROCESS:
+                return "AuthenticationProcessFailed";
+            case BiometricPrompt.ERROR_USER_CANCELED:  // actually 'user elected another auth method'
+                return "UserFallback";
+            case BiometricPrompt.ERROR_VENDOR:
+                // hardware-specific error codes
+                return "HardwareError";
+        }
+    }
+
     // TODO: use biometrioc manager to eval
     private String getErrorMessage() {
         if (!getFingerprintIdentify().isHardwareEnable()) {
@@ -131,7 +162,7 @@ public class ReactNativeFingerprintScannerModule
             return;
         }
 
-        biometricAuthenticate("Log in", promise);
+        biometricAuthenticate("Log In", promise);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -1,5 +1,7 @@
 package com.hieuvp.fingerprint;
 
+import android.os.Build;
+
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -43,6 +45,14 @@ public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaMod
         this.release();
     }
 
+    private boolean supportsFaceId() {
+        return Build.SDK_INT >= 28;   // BiometricPrompt supported on P and up
+    }
+
+    private BiometricPrompt getBiometricPrompt() {
+        // TODO
+    }
+
     private FingerprintIdentify getFingerprintIdentify() {
         if (mFingerprintIdentify != null) {
             return mFingerprintIdentify;
@@ -64,6 +74,18 @@ public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaMod
     }
 
     private String getErrorMessage() {
+        if (supportsFaceId()) {
+            return getErrorMessageBiometric();
+        }
+
+        return getErrorMessageFingerprint();
+    }
+
+    private getErrorMessageBiometric() {
+        // TODO
+    }
+
+    private String getErrorMessageFingerprint() {
         if (!getFingerprintIdentify().isHardwareEnable()) {
             return "FingerprintScannerNotSupported";
         } else if (!getFingerprintIdentify().isRegisteredFingerprint()) {
@@ -83,6 +105,14 @@ public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaMod
             return;
         }
 
+        if (supportsFaceId()) {
+            authenticateBiometric(promise);
+        }
+
+        authenticateFingerprint(promise);
+    }
+
+    private void authenticateFingerprint(final Promise promise) {
         getFingerprintIdentify().resumeIdentify();
         getFingerprintIdentify().startIdentify(MAX_AVAILABLE_TIMES, new IdentifyListener() {
             @Override
@@ -115,10 +145,18 @@ public class ReactNativeFingerprintScannerModule extends ReactContextBaseJavaMod
         });
     }
 
+    private void authenticateBiometric(final Promise promise) {
+        // TODO
+    }
+
     @ReactMethod
     public void release() {
-        getFingerprintIdentify().cancelIdentify();
-        mFingerprintIdentify = null;
+        if (supportsFaceId()) {
+            // TODO
+        } else {
+            getFingerprintIdentify().cancelIdentify();
+            mFingerprintIdentify = null;
+        }
         mReactContext.removeLifecycleEventListener(this);
     }
 

--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -170,7 +170,7 @@ public class ReactNativeFingerprintScannerModule
     }
 
     @ReactMethod
-    public void authenticate(final Promise promise, String titleText) {
+    public void authenticate(String titleText, final Promise promise) {
         final String errorName = getSensorError();
         if (errorName != null) {
             promise.reject(errorName, TYPE_BIOMETRICS);

--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -115,7 +115,7 @@ public class ReactNativeFingerprintScannerModule
         return biometricPrompt;
     }
 
-    private void biometricAuthenticate(final String titleText, final Promise promise) {
+    private void biometricAuthenticate(final String description, final Promise promise) {
         UiThreadUtil.runOnUiThread(
             new Runnable() {
                 @Override
@@ -126,7 +126,7 @@ public class ReactNativeFingerprintScannerModule
                         .setDeviceCredentialAllowed(false)
                         .setConfirmationRequired(false)
                         .setNegativeButtonText("Cancel")
-                        .setTitle(titleText)
+                        .setTitle(description)
                         .build();
 
                     bioPrompt.authenticate(promptInfo);
@@ -188,7 +188,7 @@ public class ReactNativeFingerprintScannerModule
     }
 
     @ReactMethod
-    public void authenticate(String titleText, final Promise promise) {
+    public void authenticate(String description, final Promise promise) {
         if (requiresLegacyAuthentication()) {
             legacyAuthenticate(promise);
         }
@@ -200,7 +200,7 @@ public class ReactNativeFingerprintScannerModule
                 return;
             }
 
-            biometricAuthenticate(titleText, promise);
+            biometricAuthenticate(description, promise);
         }
     }
 

--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -20,6 +20,12 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.bridge.UiThreadUtil;
 
+// for Samsung/MeiZu compat, Android v16-23
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
+import com.wei.android.lib.fingerprintidentify.FingerprintIdentify;
+import com.wei.android.lib.fingerprintidentify.base.BaseFingerprint.ExceptionListener;
+import com.wei.android.lib.fingerprintidentify.base.BaseFingerprint.IdentifyListener;
+
 
 @ReactModule(name="ReactNativeFingerprintScanner")
 public class ReactNativeFingerprintScannerModule
@@ -28,9 +34,13 @@ public class ReactNativeFingerprintScannerModule
 {
     public static final int MAX_AVAILABLE_TIMES = Integer.MAX_VALUE;
     public static final String TYPE_BIOMETRICS = "Biometrics";
+    public static final String TYPE_FINGERPRINT_LEGACY = "Fingerprint";
 
     private final ReactApplicationContext mReactContext;
     private BiometricPrompt biometricPrompt;
+
+    // for Samsung/MeiZu compat, Android v16-23
+    private FingerprintIdentify mFingerprintIdentify;
 
     public ReactNativeFingerprintScannerModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -53,6 +63,14 @@ public class ReactNativeFingerprintScannerModule
     @Override
     public void onHostDestroy() {
         this.release();
+    }
+
+    private int currentAndroidVersion() {
+        return Build.VERSION.SDK_INT;
+    }
+
+    private boolean requiresLegacyAuthentication() {
+        return currentAndroidVersion < 23;
     }
 
     public class AuthCallback extends BiometricPrompt.AuthenticationCallback {
@@ -171,18 +189,29 @@ public class ReactNativeFingerprintScannerModule
 
     @ReactMethod
     public void authenticate(String titleText, final Promise promise) {
-        final String errorName = getSensorError();
-        if (errorName != null) {
-            promise.reject(errorName, TYPE_BIOMETRICS);
-            ReactNativeFingerprintScannerModule.this.release();
-            return;
+        if (requiresLegacyAuthentication()) {
+            legacyAuthenticate(promise);
         }
+        else {
+            final String errorName = getSensorError();
+            if (errorName != null) {
+                promise.reject(errorName, TYPE_BIOMETRICS);
+                ReactNativeFingerprintScannerModule.this.release();
+                return;
+            }
 
-        biometricAuthenticate(titleText, promise);
+            biometricAuthenticate(titleText, promise);
+        }
     }
 
     @ReactMethod
     public void release() {
+        if (requiresLegacyAuthentication()) {
+            getFingerprintIdentify().cancelIdentify();
+            mFingerprintIdentify = null;
+        }
+
+        // consistent across legacy and current API
         if (biometricPrompt != null) {
             biometricPrompt.cancelAuthentication();  // if release called from eg React
         }
@@ -192,11 +221,94 @@ public class ReactNativeFingerprintScannerModule
 
     @ReactMethod
     public void isSensorAvailable(final Promise promise) {
+        if (requiresLegacyAuthentication()) {
+            String errorMessage = legacyGetErrorMessage();
+            if (errorMessage != null) {
+                promise.reject(errorMessage, TYPE_FINGERPRINT_LEGACY);
+            } else {
+                promise.resolve(TYPE_FINGERPRINT_LEGACY);
+            }
+            return;
+        }
+
+        // current API
         String errorName = getSensorError();
         if (errorName != null) {
             promise.reject(errorName, TYPE_BIOMETRICS);
         } else {
             promise.resolve(TYPE_BIOMETRICS);
         }
+    }
+
+
+    // for Samsung/MeiZu compat, Android v16-23
+    private FingerprintIdentify getFingerprintIdentify() {
+        if (mFingerprintIdentify != null) {
+            return mFingerprintIdentify;
+        }
+        mReactContext.addLifecycleEventListener(this);
+        mFingerprintIdentify = new FingerprintIdentify(mReactContext);
+        mFingerprintIdentify.setSupportAndroidL(true);
+        mFingerprintIdentify.setExceptionListener(
+            new ExceptionListener() {
+                @Override
+                public void onCatchException(Throwable exception) {
+                    mReactContext.removeLifecycleEventListener(ReactNativeFingerprintScannerModule.this);
+                }
+            }
+        );
+        mFingerprintIdentify.init();
+        return mFingerprintIdentify;
+    }
+
+    private String legacyGetErrorMessage() {
+        if (!getFingerprintIdentify().isHardwareEnable()) {
+            return "FingerprintScannerNotSupported";
+        } else if (!getFingerprintIdentify().isRegisteredFingerprint()) {
+            return "FingerprintScannerNotEnrolled";
+        } else if (!getFingerprintIdentify().isFingerprintEnable()) {
+            return "FingerprintScannerNotAvailable";
+        }
+    }
+
+
+    private void legacyAuthenticate(final Promise promise) {
+        final String errorMessage = legacyGetErrorMessage();
+        if (errorMessage != null) {
+            promise.reject(errorMessage, TYPE_FINGERPRINT_LEGACY);
+            ReactNativeFingerprintScannerModule.this.release();
+            return;
+        }
+
+        getFingerprintIdentify().resumeIdentify();
+        getFingerprintIdentify().startIdentify(MAX_AVAILABLE_TIMES, new IdentifyListener() {
+            @Override
+            public void onSucceed() {
+                promise.resolve(true);
+                ReactNativeFingerprintScannerModule.this.release();
+            }
+
+            @Override
+            public void onNotMatch(int availableTimes) {
+                mReactContext.getJSModule(RCTDeviceEventEmitter.class)
+                    .emit("FINGERPRINT_SCANNER_AUTHENTICATION", "AuthenticationNotMatch");
+            }
+
+            @Override
+            public void onFailed(boolean isDeviceLocked) {
+                if(isDeviceLocked){
+                    promise.reject("AuthenticationFailed", "DeviceLocked");
+                } else {
+                    promise.reject("AuthenticationFailed", TYPE_FINGERPRINT);
+                }
+                ReactNativeFingerprintScannerModule.this.release();
+            }
+
+            @Override
+            public void onStartFailedByDeviceLocked() {
+                // the first start failed because the device was locked temporarily
+                promise.reject("AuthenticationFailed", "DeviceLocked");
+            }
+        });
     }
 }

--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -70,7 +70,7 @@ public class ReactNativeFingerprintScannerModule
     }
 
     private boolean requiresLegacyAuthentication() {
-        return currentAndroidVersion < 23;
+        return currentAndroidVersion() < 23;
     }
 
     public class AuthCallback extends BiometricPrompt.AuthenticationCallback {
@@ -269,6 +269,8 @@ public class ReactNativeFingerprintScannerModule
         } else if (!getFingerprintIdentify().isFingerprintEnable()) {
             return "FingerprintScannerNotAvailable";
         }
+
+        return null;
     }
 
 
@@ -299,7 +301,7 @@ public class ReactNativeFingerprintScannerModule
                 if(isDeviceLocked){
                     promise.reject("AuthenticationFailed", "DeviceLocked");
                 } else {
-                    promise.reject("AuthenticationFailed", TYPE_FINGERPRINT);
+                    promise.reject("AuthenticationFailed", TYPE_FINGERPRINT_LEGACY);
                 }
                 ReactNativeFingerprintScannerModule.this.release();
             }

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,10 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <!-- API lvl 27- (Oreo MR1 and below) -->
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <!-- API lvl 28+ (Pie and above) -->
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "29.0.2"
         minSdkVersion = 16
-        compileSdkVersion = 28
-        targetSdkVersion = 28
-        supportLibVersion = "28.0.0"
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+        supportLibVersion = "29.0.0"
     }
     repositories {
         google()

--- a/examples/src/FingerprintPopup.component.android.js
+++ b/examples/src/FingerprintPopup.component.android.js
@@ -1,87 +1,34 @@
+import { Component } from 'react';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import {
-  Alert,
-  Image,
-  Text,
-  TouchableOpacity,
-  View,
-  ViewPropTypes
-} from 'react-native';
+
 import FingerprintScanner from 'react-native-fingerprint-scanner';
 
-import styles from './FingerprintPopup.component.styles';
-import ShakingText from './ShakingText.component';
 
-class FingerprintPopup extends Component {
-
+// Based on https://github.com/hieuvp/react-native-fingerprint-scanner/blob/master/examples/src/FingerprintPopup.component.android.js
+class BiometricPopup extends Component {
   constructor(props) {
     super(props);
-    this.state = { errorMessage: undefined, biometric: undefined };
+    this.state = {};
   }
 
   componentDidMount() {
     FingerprintScanner
-      .authenticate({ onAttempt: this.handleAuthenticationAttempted })
+      .authenticate({ titleText: 'Log in with Biometrics' })
       .then(() => {
-        this.props.handlePopupDismissed();
-        Alert.alert('Fingerprint Authentication', 'Authenticated successfully');
-      })
-      .catch((error) => {
-        this.setState({ errorMessage: error.message, biometric: error.biometric });
-        this.description.shake();
+        this.props.onAuthenticate();
       });
   }
 
-  componentWillUnmount() {
+  componentWillUnmount = () => {
     FingerprintScanner.release();
   }
 
-  handleAuthenticationAttempted = (error) => {
-    this.setState({ errorMessage: error.message });
-    this.description.shake();
-  };
-
-  render() {
-    const { errorMessage, biometric } = this.state;
-    const { style, handlePopupDismissed } = this.props;
-
-    return (
-      <View style={styles.container}>
-        <View style={[styles.contentContainer, style]}>
-
-          <Image
-            style={styles.logo}
-            source={require('./assets/finger_print.png')}
-          />
-
-          <Text style={styles.heading}>
-            Biometric{'\n'}Authentication
-          </Text>
-          <ShakingText
-            ref={(instance) => { this.description = instance; }}
-            style={styles.description(!!errorMessage)}>
-            {errorMessage || `Scan your ${biometric} on the\ndevice scanner to continue`}
-          </ShakingText>
-
-          <TouchableOpacity
-            style={styles.buttonContainer}
-            onPress={handlePopupDismissed}
-          >
-            <Text style={styles.buttonText}>
-              BACK TO MAIN
-            </Text>
-          </TouchableOpacity>
-
-        </View>
-      </View>
-    );
-  }
+  render = () => null
 }
 
-FingerprintPopup.propTypes = {
-  style: ViewPropTypes.style,
-  handlePopupDismissed: PropTypes.func.isRequired,
+BiometricPopup.propTypes = {
+  onAuthenticate: PropTypes.func.isRequired,
 };
 
-export default FingerprintPopup;
+export default BiometricPopup;
+

--- a/examples/src/FingerprintPopup.component.android.js
+++ b/examples/src/FingerprintPopup.component.android.js
@@ -49,7 +49,7 @@ class BiometricPopup extends Component {
 
   authCurrent() {
     FingerprintScanner
-      .authenticate({ titleText: this.props.titleText || 'Log in with Biometrics' })
+      .authenticate({ description: this.props.description || 'Log in with Biometrics' })
       .then(() => {
         this.props.onAuthenticate();
       });
@@ -121,7 +121,7 @@ class BiometricPopup extends Component {
 }
 
 BiometricPopup.propTypes = {
-  titleText: PropTypes.string,
+  description: PropTypes.string,
   onAuthenticate: PropTypes.func.isRequired,
   handlePopupDismissedLegacy: PropTypes.func,
   style: ViewPropTypes.style,

--- a/examples/src/FingerprintPopup.component.android.js
+++ b/examples/src/FingerprintPopup.component.android.js
@@ -49,7 +49,7 @@ class BiometricPopup extends Component {
 
   authCurrent() {
     FingerprintScanner
-      .authenticate({ titleText: 'Log in with Biometrics' })
+      .authenticate({ titleText: this.props.titleText || 'Log in with Biometrics' })
       .then(() => {
         this.props.onAuthenticate();
       });
@@ -121,6 +121,7 @@ class BiometricPopup extends Component {
 }
 
 BiometricPopup.propTypes = {
+  titleText: PropTypes.string,
   onAuthenticate: PropTypes.func.isRequired,
   handlePopupDismissedLegacy: PropTypes.func,
   style: ViewPropTypes.style,

--- a/examples/src/FingerprintPopup.component.android.js
+++ b/examples/src/FingerprintPopup.component.android.js
@@ -1,17 +1,53 @@
-import { Component } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import {
+  Alert,
+  Image,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewPropTypes,
+  Platform,
+} from 'react-native';
 
 import FingerprintScanner from 'react-native-fingerprint-scanner';
+import styles from './FingerprintPopup.component.styles';
+import ShakingText from './ShakingText.component';
+
 
 
 // Based on https://github.com/hieuvp/react-native-fingerprint-scanner/blob/master/examples/src/FingerprintPopup.component.android.js
+// - this example component supports both the legacy device-specific (Android < v23) and
+//   current (Android >= 23) biometric APIs
+// - your lib and implementation may not need both
 class BiometricPopup extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      errorMessageLegacy: undefined,
+      biometricLegacy: undefined
+    };
+
+    this.description = null;
   }
 
   componentDidMount() {
+    if (requiresLegacyAuthentication()) {
+      authLegacy();
+    } else {
+      authCurrent();
+    }
+  }
+
+  componentWillUnmount = () => {
+    FingerprintScanner.release();
+  }
+
+  requiresLegacyAuthentication() {
+    return Platform.Version < 23;
+  }
+
+  authCurrent() {
     FingerprintScanner
       .authenticate({ titleText: 'Log in with Biometrics' })
       .then(() => {
@@ -19,15 +55,75 @@ class BiometricPopup extends Component {
       });
   }
 
-  componentWillUnmount = () => {
-    FingerprintScanner.release();
+  authLegacy() {
+    FingerprintScanner
+      .authenticate({ onAttempt: this.handleAuthenticationAttemptedLegacy })
+      .then(() => {
+        this.props.handlePopupDismissedLegacy();
+        Alert.alert('Fingerprint Authentication', 'Authenticated successfully');
+      })
+      .catch((error) => {
+        this.setState({ errorMessageLegacy: error.message, biometricLegacy: error.biometric });
+        this.description.shake();
+      });
   }
 
-  render = () => null
+  handleAuthenticationAttemptedLegacy = (error) => {
+    this.setState({ errorMessageLegacy: error.message });
+    this.description.shake();
+  };
+
+  renderLegacy() {
+    const { errorMessageLegacy, biometricLegacy } = this.state;
+    const { style, handlePopupDismissedLegacy } = this.props;
+
+    return (
+      <View style={styles.container}>
+        <View style={[styles.contentContainer, style]}>
+
+          <Image
+            style={styles.logo}
+            source={require('./assets/finger_print.png')}
+          />
+
+          <Text style={styles.heading}>
+            Biometric{'\n'}Authentication
+          </Text>
+          <ShakingText
+            ref={(instance) => { this.description = instance; }}
+            style={styles.description(!!errorMessageLegacy)}>
+            {errorMessageLegacy || `Scan your ${biometricLegacy} on the\ndevice scanner to continue`}
+          </ShakingText>
+
+          <TouchableOpacity
+            style={styles.buttonContainer}
+            onPress={handlePopupDismissedLegacy}
+          >
+            <Text style={styles.buttonText}>
+              BACK TO MAIN
+            </Text>
+          </TouchableOpacity>
+
+        </View>
+      </View>
+    );
+  }
+
+
+  render = () => {
+    if (this.requiresLegacyAuthentication()) {
+      return this.renderLegacy();
+    }
+
+    // current API UI provided by native BiometricPrompt
+    return null;
+  }
 }
 
 BiometricPopup.propTypes = {
   onAuthenticate: PropTypes.func.isRequired,
+  handlePopupDismissedLegacy: PropTypes.func,
+  style: ViewPropTypes.style,
 };
 
 export default BiometricPopup;

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,19 +129,23 @@ export interface FingerPrintProps {
           this.props.handlePopupDismissed();
           AlertIOS.alert(error.message);
         });
-      ```     
+      ```
       -----------------
-      
-      ### authenticate({ titleText: 'Log in with Biometrics' }): (Android)
+
+      ### authenticate({ titleText: 'Log in with Biometrics', onAttempt: () => (null) }): (Android)
 
       - Returns a `Promise`
       - `titleText: String` - the title text to appear on the native Android prompt
+      - `onAttempt: Function` - a callback function when users are trying to scan their fingerprint but failed.
 
       -----------------
       - Example:
       ```
       FingerprintScanner
-        .authenticate({ titleText: 'Log in with Biometrics' })
+        .authenticate({
+          titleText: 'Log in with Biometrics',
+          onAttempt: this.handleAuthenticationAttempted,
+        })
         .then(() => {
           this.props.handlePopupDismissed();
           Alert.alert('Fingerprint Authentication', 'Authenticated successfully');

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,10 +132,10 @@ export interface FingerPrintProps {
       ```
       -----------------
 
-      ### authenticate({ titleText: 'Log in with Biometrics', onAttempt: () => (null) }): (Android)
+      ### authenticate({ description: 'Log in with Biometrics', onAttempt: () => (null) }): (Android)
 
       - Returns a `Promise`
-      - `titleText: String` - the title text to appear on the native Android prompt
+      - `description: String` - the title text to appear on the native Android prompt
       - `onAttempt: Function` - a callback function when users are trying to scan their fingerprint but failed.
 
       -----------------
@@ -143,7 +143,7 @@ export interface FingerPrintProps {
       ```
       FingerprintScanner
         .authenticate({
-          titleText: 'Log in with Biometrics',
+          description: 'Log in with Biometrics',
           onAttempt: this.handleAuthenticationAttempted,
         })
         .then(() => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export type AuthenticateIOS = {
 };
 export type AuthenticateAndroid = { onAttempt: (error: FingerprintScannerError) => void };
 
-export type Biometrics = 'Touch ID' | 'Face ID' | 'Fingerprint';
+export type Biometrics = 'Touch ID' | 'Face ID' | 'Biometrics';
 
 export type Errors =
   | { name: 'AuthenticationNotMatch'; message: 'No match' }

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,14 @@ export type Errors =
       message: 'Authentication was not successful because the user failed to provide valid credentials';
     }
   | {
+      name: 'AuthenticationTimeout';
+      message: 'Authentication was not successful because the operation timed out.';
+    }
+  | {
+      name: 'AuthenticationProcessFailed';
+      message: 'Sensor was unable to process the image. Please try again.';
+    }
+  | {
       name: 'UserCancel';
       message: 'Authentication was canceled by the user - e.g. the user tapped Cancel in the dialog';
     }
@@ -47,6 +55,18 @@ export type Errors =
   | {
       name: 'DeviceLocked';
       message: 'Authentication was not successful, the device currently in a lockout of 30 seconds';
+    }
+  | {
+      name: 'DeviceLockedPermanent';
+      message: 'Authentication was not successful, device must be unlocked via password.';
+    }
+  | {
+      name: 'DeviceOutOfMemory';
+      message: 'Authentication could not proceed because there is not enough free memory on the device.';
+    }
+  | {
+      name: 'HardwareError';
+      message: 'A hardware error occurred.';
     };
 
 export type FingerprintScannerError = { biometric: Biometrics } & Errors;
@@ -112,16 +132,16 @@ export interface FingerPrintProps {
       ```     
       -----------------
       
-      ### authenticate({ onAttempt }): (Android)
+      ### authenticate({ titleText: 'Log in with Biometrics' }): (Android)
 
       - Returns a `Promise`
-      - `onAttempt: Function` - a callback function when users are trying to scan their fingerprint but failed.
+      - `titleText: String` - the title text to appear on the native Android prompt
 
       -----------------
       - Example:
       ```
       FingerprintScanner
-        .authenticate({ onAttempt: this.handleAuthenticationAttempted })
+        .authenticate({ titleText: 'Log in with Biometrics' })
         .then(() => {
           this.props.handlePopupDismissed();
           Alert.alert('Fingerprint Authentication', 'Authenticated successfully');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "react-native-fingerprint-scanner",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-fingerprint-scanner",
-  "version": "3.0.2",
-  "description": "React Native Fingerprint Scanner for Android and iOS",
+  "version": "4.0.0",
+  "description": "React Native Biometrics Scanner for Android and iOS",
   "main": "index.js",
   "keywords": [
     "react-native",
@@ -16,7 +16,10 @@
     "fingerprint-scanner",
     "authentication",
     "authenticate",
-    "auth"
+    "auth",
+    "face-id",
+    "faceid",
+    "biometrics"
   ],
   "peerDependencies": {
     "react-native": ">=0.60 <1.0.0"

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -1,4 +1,4 @@
-import { DeviceEventEmitter, NativeModules } from 'react-native';
+import { NativeModules } from 'react-native';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -1,11 +1,10 @@
 import { DeviceEventEmitter, NativeModules } from 'react-native';
-import createError from './createError';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
-export default ({ onAttempt }) => {
+export default ({ titleText="Log In" }) => {
   return new Promise((resolve, reject) => {
-    ReactNativeFingerprintScanner.authenticate()
+    ReactNativeFingerprintScanner.authenticate(titleText)
       .then(() => {
         resolve(true);
       })

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -47,7 +47,7 @@ export default ({ description, onAttempt }) => {
       onAttempt = nullOnAttempt;
     }
 
-    if (Platform.VERSION < 23) {
+    if (Platform.Version < 23) {
       return authLegacy(onAttempt);
     }
 

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -7,8 +7,8 @@ import createError from './createError';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
-const authCurrent = (titleText) => {
-  ReactNativeFingerprintScanner.authenticate(titleText)
+const authCurrent = (description) => {
+  ReactNativeFingerprintScanner.authenticate(description)
     .then(() => {
       resolve(true);
     })
@@ -38,12 +38,12 @@ const authLegacy = (onAttempt) => {
 
 const nullOnAttempt = () => null;
 
-export default ({ titleText="Log In", onAttempt=nullOnAttempt }) => {
+export default ({ description="Log In", onAttempt=nullOnAttempt }) => {
   return new Promise((resolve, reject) => {
     if (Platform.VERSION < 23) {
       return authLegacy(onAttempt);
     }
 
-    return authCurrent(titleText);
+    return authCurrent(description);
   });
 }

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -38,8 +38,15 @@ const authLegacy = (onAttempt) => {
 
 const nullOnAttempt = () => null;
 
-export default ({ description="Log In", onAttempt=nullOnAttempt }) => {
+export default ({ description, onAttempt }) => {
   return new Promise((resolve, reject) => {
+    if (!description) {
+      description = "Log In";
+    }
+    if (!onAttempt) {
+      onAttempt = nullOnAttempt;
+    }
+
     if (Platform.VERSION < 23) {
       return authLegacy(onAttempt);
     }

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -5,19 +5,12 @@ const { ReactNativeFingerprintScanner } = NativeModules;
 
 export default ({ onAttempt }) => {
   return new Promise((resolve, reject) => {
-    DeviceEventEmitter.addListener('FINGERPRINT_SCANNER_AUTHENTICATION', (name) => {
-      if (name === 'AuthenticationNotMatch' && typeof onAttempt === 'function') {
-        onAttempt(createError(name));
-      }
-    });
-
     ReactNativeFingerprintScanner.authenticate()
       .then(() => {
-        DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
         resolve(true);
       })
       .catch((error) => {
-        DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
+        // translate errors
         reject(createError(error.code, error.message));
       });
   });

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -1,16 +1,49 @@
-import { NativeModules } from 'react-native';
+import {
+  DeviceEventEmitter,
+  NativeModules,
+  Platform,
+} from 'react-native';
+import createError from './createError';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
-export default ({ titleText="Log In" }) => {
+const authCurrent = (titleText) => {
+  ReactNativeFingerprintScanner.authenticate(titleText)
+    .then(() => {
+      resolve(true);
+    })
+    .catch((error) => {
+      // translate errors
+      reject(createError(error.code, error.message));
+    });
+}
+
+const authLegacy = (onAttempt) => {
+  DeviceEventEmitter.addListener('FINGERPRINT_SCANNER_AUTHENTICATION', (name) => {
+    if (name === 'AuthenticationNotMatch' && typeof onAttempt === 'function') {
+      onAttempt(createError(name));
+    }
+  });
+
+  ReactNativeFingerprintScanner.authenticate()
+    .then(() => {
+      DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
+      resolve(true);
+    })
+    .catch((error) => {
+      DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
+      reject(createError(error.code, error.message));
+    });
+}
+
+const nullOnAttempt = () => null;
+
+export default ({ titleText="Log In", onAttempt=nullOnAttempt }) => {
   return new Promise((resolve, reject) => {
-    ReactNativeFingerprintScanner.authenticate(titleText)
-      .then(() => {
-        resolve(true);
-      })
-      .catch((error) => {
-        // translate errors
-        reject(createError(error.code, error.message));
-      });
+    if (Platform.VERSION < 23) {
+      return authLegacy(onAttempt);
+    }
+
+    return authCurrent(titleText);
   });
 }

--- a/src/createError.js
+++ b/src/createError.js
@@ -1,4 +1,10 @@
 const ERRORS = {
+  // sensor availability
+  FingerprintScannerNotSupported: 'Device does not support Fingerprint Scanner.',
+  FingerprintScannerNotEnrolled: 'Authentication could not start because Fingerprint Scanner has no enrolled fingers.',
+  FingerprintScannerNotAvailable: 'Authentication could not start because Fingerprint Scanner is not available on the device.',
+
+  // auth failures
   AuthenticationNotMatch: 'No match.',
   AuthenticationFailed: 'Authentication was not successful because the user failed to provide valid credentials.',
   AuthenticationTimeout: 'Authentication was not successful because the operation timed out.',
@@ -7,10 +13,7 @@ const ERRORS = {
   UserFallback: 'Authentication was canceled because the user tapped the fallback button (Enter Password).',
   SystemCancel: 'Authentication was canceled by system - e.g. if another application came to foreground while the authentication dialog was up.',
   PasscodeNotSet: 'Authentication could not start because the passcode is not set on the device.',
-  FingerprintScannerNotAvailable: 'Authentication could not start because Fingerprint Scanner is not available on the device.',
-  FingerprintScannerNotEnrolled: 'Authentication could not start because Fingerprint Scanner has no enrolled fingers.',
   FingerprintScannerUnknownError: 'Could not authenticate for an unknown reason.',
-  FingerprintScannerNotSupported: 'Device does not support Fingerprint Scanner.',
   DeviceLocked: 'Authentication was not successful, the device currently in a lockout of 30 seconds.',
   DeviceLockedPermanent: 'Authentication was not successful, device must be unlocked via password.',
   DeviceOutOfMemory: 'Authentication could not proceed because there is not enough free memory on the device.',

--- a/src/createError.js
+++ b/src/createError.js
@@ -1,6 +1,8 @@
 const ERRORS = {
   AuthenticationNotMatch: 'No match.',
   AuthenticationFailed: 'Authentication was not successful because the user failed to provide valid credentials.',
+  AuthenticationTimeout: 'Authentication was not successful because the operation timed out.',
+  AuthenticationProcessFailed: 'Sensor was unable to process the image. Please try again.',
   UserCancel: 'Authentication was canceled by the user - e.g. the user tapped Cancel in the dialog.',
   UserFallback: 'Authentication was canceled because the user tapped the fallback button (Enter Password).',
   SystemCancel: 'Authentication was canceled by system - e.g. if another application came to foreground while the authentication dialog was up.',
@@ -9,7 +11,10 @@ const ERRORS = {
   FingerprintScannerNotEnrolled: 'Authentication could not start because Fingerprint Scanner has no enrolled fingers.',
   FingerprintScannerUnknownError: 'Could not authenticate for an unknown reason.',
   FingerprintScannerNotSupported: 'Device does not support Fingerprint Scanner.',
-  DeviceLocked: 'Authentication was not successful, the device currently in a lockout of 30 seconds'
+  DeviceLocked: 'Authentication was not successful, the device currently in a lockout of 30 seconds.',
+  DeviceLockedPermanent: 'Authentication was not successful, device must be unlocked via password.',
+  DeviceOutOfMemory: 'Authentication could not proceed because there is not enough free memory on the device.',
+  HardwareError: 'A hardware error occurred.',
 };
 
 class FingerprintScannerError extends Error {

--- a/src/release.android.js
+++ b/src/release.android.js
@@ -1,7 +1,11 @@
-import { NativeModules } from 'react-native';
+import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
 export default () => {
+  if (Platform.VERSION < 23) {
+    DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
+  }
+
   ReactNativeFingerprintScanner.release();
 }

--- a/src/release.android.js
+++ b/src/release.android.js
@@ -6,3 +6,4 @@ export default () => {
   DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
   ReactNativeFingerprintScanner.release();
 }
+export default () => null;

--- a/src/release.android.js
+++ b/src/release.android.js
@@ -1,9 +1,8 @@
-import { DeviceEventEmitter, NativeModules } from 'react-native';
+import { NativeModules } from 'react-native';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
 export default () => {
-  DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
   ReactNativeFingerprintScanner.release();
 }
 export default () => null;

--- a/src/release.android.js
+++ b/src/release.android.js
@@ -3,7 +3,7 @@ import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
 const { ReactNativeFingerprintScanner } = NativeModules;
 
 export default () => {
-  if (Platform.VERSION < 23) {
+  if (Platform.Version < 23) {
     DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
   }
 

--- a/src/release.android.js
+++ b/src/release.android.js
@@ -5,4 +5,3 @@ const { ReactNativeFingerprintScanner } = NativeModules;
 export default () => {
   ReactNativeFingerprintScanner.release();
 }
-export default () => null;


### PR DESCRIPTION
Provides native prompt to authenticate; brings Android to parity with iOS

- isSensorAvailable uses android BiometricManager
  - provides 'Biometrics' biometryType, as opposed to 'Fingerprint'
  - on Android Q (v29)+, uses device's preferred biometry type (user-decided)
  - on Android P (v28) and below, defaults to Fingerprint, supported by FingerprintCompat lib
  - on Android M-P (v23), checks for native fingerprint support on device (Samsung & MeiZu), and defaults to it if available
    - prefers Android native > other device native
- authenticate uses android BiometricPrompt
  - now provides native prompt, ~as opposed to~ in addition to a lower-level key-signing API
  - now accepts description parameter for title text
  - in v23+, removes onAttempt, as event emitting can be removed from app in favor of being handled by promise resolve/rejection
- update README and examples doc to reflect

~~These are breaking changes, but perhaps are necessary as the underlying package for Android is fundamentally different~~ No longer any breaking changes