### PR TITLE
Passcode fallback for when user fails biometric multiple times.

### DIFF
--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -56,9 +56,9 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     }
 
     // Device has FingerprintScanner
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         // Attempt Authentication
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {


### PR DESCRIPTION
It might be possible that the user doesn't have biometric access(wet hands etc) but knows lock screen passcode. Then user can use the passcode to authenticate.