### PR TITLE
Fix permanent device lockout error message.

### DIFF
--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -146,7 +146,7 @@ public class ReactNativeFingerprintScannerModule
             case BiometricPrompt.ERROR_LOCKOUT:
                 return "DeviceLocked";
             case BiometricPrompt.ERROR_LOCKOUT_PERMANENT:
-                return "DeviceLocked";
+                return "DeviceLockedPermanent";
             case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
                 return "UserCancel";
             case BiometricPrompt.ERROR_NO_BIOMETRICS:


### PR DESCRIPTION
Fix permanent device lockout error message for android to get different messages for temporary and permanent lockouts.