### PR TITLE
Update authenticate.android.js

### DIFF
--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -18,14 +18,14 @@ const authCurrent = (title, subTitle, description, cancelButton, resolve, reject
     });
 }
 
-const authLegacy = (onAttempt, resolve, reject) => {
+const authLegacy = (title, subTitle, description, cancelButton, onAttempt, resolve, reject) => {
   DeviceEventEmitter.addListener('FINGERPRINT_SCANNER_AUTHENTICATION', (name) => {
     if (name === 'AuthenticationNotMatch' && typeof onAttempt === 'function') {
       onAttempt(createError(name));
     }
   });
 
-  ReactNativeFingerprintScanner.authenticate()
+  ReactNativeFingerprintScanner.authenticate(title, subTitle, description, cancelButton)
     .then(() => {
       DeviceEventEmitter.removeAllListeners('FINGERPRINT_SCANNER_AUTHENTICATION');
       resolve(true);
@@ -58,7 +58,7 @@ export default ({ title, subTitle, description, cancelButton, onAttempt }) => {
     }
 
     if (Platform.Version < 23) {
-      return authLegacy(onAttempt, resolve, reject);
+      return authLegacy(title, subTitle, description, cancelButton, onAttempt, resolve, reject);
     }
 
     return authCurrent(title, subTitle, description, cancelButton, resolve, reject);


### PR DESCRIPTION
Crash in case of calling authenticate function on android < 23 as authenticate method in Java does not have such interface.
Also fix for such crashes:
https://github.com/hieuvp/react-native-fingerprint-scanner/issues/153
https://github.com/hieuvp/react-native-fingerprint-scanner/issues/158