### PR TITLE
Cleaning prompt on authcallback to avoid errors

### DIFF
--- a/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
+++ b/android/src/main/java/com/hieuvp/fingerprint/ReactNativeFingerprintScannerModule.java
@@ -83,12 +83,14 @@ public class ReactNativeFingerprintScannerModule
 
         @Override
         public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
+            biometricPrompt = null;
             super.onAuthenticationError(errorCode, errString);
             this.promise.reject(biometricPromptErrName(errorCode), TYPE_BIOMETRICS);
         }
 
         @Override
         public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
+            biometricPrompt = null;
             super.onAuthenticationSucceeded(result);
             this.promise.resolve(true);
         }


### PR DESCRIPTION
On our application, on the second time we try to authenticate, the promise is never resolved or reject.

Cleaning the biometric prompt after the authentication solves this