### PR TITLE
Add fallback files in case lib isn't available for a platform

### DIFF
--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -1,0 +1,7 @@
+import { Platform } from 'react-native';
+
+export default () => {
+  return new Promise((_, reject) => {
+    reject(new Error(`react-native-fingerprint-scanner is not available for ${Platform.OS}`))
+  });
+}

--- a/src/isSensorAvailable.js
+++ b/src/isSensorAvailable.js
@@ -1,0 +1,7 @@
+import { Platform } from 'react-native';
+
+export default () => {
+  return new Promise((_, reject) => {
+    reject(new Error(`react-native-fingerprint-scanner is not available for ${Platform.OS}`))
+  });
+}

--- a/src/release.js
+++ b/src/release.js
@@ -1,0 +1,7 @@
+import { Platform } from 'react-native';
+
+export default () => {
+  return new Promise((_, reject) => {
+    reject(new Error(`react-native-fingerprint-scanner is not available for ${Platform.OS}`))
+  });
+}


### PR DESCRIPTION
This PR will make sure an Error is thrown is case the lib is used on an unsupported platform.
Metro would fail to even load the lib if there aren't any fallback files (without android.js etc), which makes it difficult to port apps to different platforms (windows, macos, web etc...).