### PR TITLE
android: remove legacy support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,10 +44,4 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     // androidx:biometric now supports fingerprint back to Android v23
     implementation "androidx.biometric:biometric:1.1.0"
-
-    // retain fingerprintScanner lib for compat with Android v16-23 device-specific drivers (Samsung & MeiZu)
-    // 1.2.3 is the minimum version compatible with androidx.
-    // See https://github.com/uccmawei/FingerprintIdentify/issues/74
-    // (translation https://translate.google.com/translate?sl=zh-CN&tl=en&u=https://github.com/uccmawei/FingerprintIdentify/issues/74)
-    implementation "com.github.uccmawei:fingerprintidentify:${safeExtGet("fingerprintidentify", "1.2.6")}"
 }


### PR DESCRIPTION
Legacy support depends on non-free software.
That, in turn, prevents other software, which depends on r-n-f-s to become non-free.

https://github.com/hieuvp/react-native-fingerprint-scanner/issues/240