### PR TITLE
[FIX] Fix the error "Could not find com.wei.android.lib:fingerprintid…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,5 +49,5 @@ dependencies {
     // 1.2.3 is the minimum version compatible with androidx.
     // See https://github.com/uccmawei/FingerprintIdentify/issues/74
     // (translation https://translate.google.com/translate?sl=zh-CN&tl=en&u=https://github.com/uccmawei/FingerprintIdentify/issues/74)
-    implementation "com.github.uccmawei:fingerprintidentify:${safeExtGet("fingerprintidentify", "1.2.6")}"
+    implementation 'com.github.uccmawei:FingerprintIdentify:1.2.6'
 }


### PR DESCRIPTION
…entify:1.2.6." when building the application.