### PR TITLE
Add explicit  LICENSE file in the root of the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 The Project's Authors and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi everyone,

Based on your [README](https://github.com/hieuvp/react-native-fingerprint-scanner/blob/3898597b031ebf4b2f685958b7de0a755bb8fb16/README.md?plain=1#L473) and [package.json](https://github.com/hieuvp/react-native-fingerprint-scanner/blob/3898597b031ebf4b2f685958b7de0a755bb8fb16/package.json#L30) files, I understand that the license for this repository is MIT. Is that correct?

This PR adds an explicit `LICENSE` file, which will clarify the project's licensing terms and allow the community to confidently fork and redistribute modified versions of the code.

The copyright year is set to `2017`, the year this repository was created, and the copyright holder is listed as `The Project's Authors and Contributors`, in line with the comments from a previous [issue](https://github.com/hieuvp/react-native-fingerprint-scanner/issues/91#issuecomment-520626532).

Let me know if there are any suggestions or changes required.

Thank you!

<hr />

Closes https://github.com/hieuvp/react-native-fingerprint-scanner/issues/91